### PR TITLE
Extract payload from file drop event data

### DIFF
--- a/vue-components/src/components/TauriWindow.js
+++ b/vue-components/src/components/TauriWindow.js
@@ -142,8 +142,8 @@ export default {
       })
     );
     subscriptions.push(
-      webView.onFileDropEvent((event) => {
-        emit("fileDrop", event);
+      webView.onFileDropEvent(({ payload }) => {
+        emit("fileDrop", payload);
       })
     );
     subscriptions.push(


### PR DESCRIPTION
If I did it correctly, should change `{'event': 'tauri://file-drop', 'windowLabel': 'tauri_window_0', 'payload': {'type': 'drop', 'paths': ['FILE_PATH']}, 'id': 1443904229}` to `{'type': 'drop', 'paths': ['FILE_PATH']}`